### PR TITLE
Load ox for using its function

### DIFF
--- a/blog-admin-backend-hexo.el
+++ b/blog-admin-backend-hexo.el
@@ -23,6 +23,7 @@
 
 ;;; Code:
 
+(require 'ox)
 (require 'blog-admin-backend)
 
 (defvar blog-admin-backend-hexo-default-file-type 'markdown


### PR DESCRIPTION
I got a following error at byte-compiling.

```
blog-admin.el:33:1:Error: Symbol's function definition is void: org-export-define-derived-backend
```
