### PR TITLE
Correctly set the table row and column.

### DIFF
--- a/blog-admin.el
+++ b/blog-admin.el
@@ -156,6 +156,7 @@ r   ... Refresh blog-admin
       (load-map)
       (start)
       (goto-char old-point)
+      (ctbl:navi-move-gen 0 0)
       )))
 ;; main
 


### PR DESCRIPTION
Simply setting the point to old position doesn't actually fix the row
selection on refresh.  We fix this by moving 0 rows and 0 columns.
