### PR TITLE
Support format configuration for new posts with nikola

### DIFF
--- a/blog-admin-backend-nikola.el
+++ b/blog-admin-backend-nikola.el
@@ -40,6 +40,9 @@
 (defvar config-file "conf.py"
   "filename for nikola configuration file")
 
+(defvar post-format "rest"
+  "format for new posts. See nikola new_post -F to see your possibilities.")
+
 ;; nikola define
 
 (defun -find-lines (prefix)
@@ -161,8 +164,8 @@ Currently returns '(filename modification-time)"
   (interactive "MTitle: ")
   (let* ((tags (if blog-admin-backend-new-post-in-drafts "--tags=draft" ""))
          (command (format
-                   "cd %s && %s new_post %s -t \"%s\""
-                   blog-admin-backend-path executable tags title))
+                   "cd %s && %s new_post %s -t \"%s\" -f \"%s\""
+                   blog-admin-backend-path executable tags title post-format))
          (command- (or (and import-from (format "%s -i %s" command import-from))
                        command))
          (output (shell-command-to-string command-))


### PR DESCRIPTION
This is because I use orgmode instead of reStructuredText for the posts I create.

now I simply do 

> (setq blog-admin-backend-nikola-post-format "orgmode")

in my init.el and it works fine.

(we have to use the orgmode plugin in order to use orgmode with nikola, but thats a simple installation, this pull should work for all formats supported by nikola)
