### PR TITLE
Set default-directory in admin buffer

### DIFF
--- a/blog-admin.el
+++ b/blog-admin.el
@@ -193,6 +193,7 @@ F   ... Filter and show only rows with keyword
   (interactive)
   (setq mode-buffer (get-buffer-create "*Blog*"))
   (switch-to-buffer mode-buffer)
+  (setq-local default-directory blog-admin-backend-path)
   (setq buffer-read-only nil)
   (erase-buffer)
   (load-map)


### PR DESCRIPTION
It is useful to have the default directory set to
`blog-admin-backend-path` in the blog admin buffer. Common functions
like `find-file`, etc. become more useful.
