### PR TITLE
Update blog-admin-backend-hexo.el

### DIFF
--- a/blog-admin-backend-hexo.el
+++ b/blog-admin-backend-hexo.el
@@ -58,7 +58,7 @@ categories:
          (mapcar
           (lambda (append-path)
             "scan files with append-path"
-            (directory-files (blog-admin-backend--full-path append-path) t "^.*\\.\\(org\\|md\\|markdown\\)$"))
+            (directory-files (blog-admin-backend--full-path append-path) t "^[^.]*\\.\\(org\\|md\\|markdown\\)$"))
           (list posts-dir drafts-dir)
           )))
 


### PR DESCRIPTION
不扫描目录中的隐藏文件，特别是.#开头的临时文件
当修改文件未保存时产生的临时文件不在当前目录而是链接过来的时候，运行报错，提示找不到文件，列表不显示。