### PR TITLE
add --config to the command used by build and deploy in backend hexo

### DIFF
--- a/blog-admin-backend-hexo.el
+++ b/blog-admin-backend-hexo.el
@@ -148,16 +148,16 @@ categories:
   "Build the site."
   (interactive)
   (let ((command (format
-                  "cd %s && hexo generate &"
-                  blog-admin-backend-path)))
+                  "cd %s && hexo --config %s generate &"
+                  blog-admin-backend-path config-file)))
     (shell-command command)))
 
 (defun deploy-site ()
   "Deploy the site."
   (interactive)
   (let ((command (format
-                  "cd %s && hexo deploy --generate &"
-                  blog-admin-backend-path)))
+                  "cd %s && hexo --config %s deploy --generate &"
+                  blog-admin-backend-path config-file)))
     (shell-command command)))
 
 (defun open-site-config ()


### PR DESCRIPTION
fixbug: hexo backend ignore config file while deploying and building.

If users don't use default config file ( `_config.yml` ),  files generated by building command are wrong, and the command of deploy won't work.